### PR TITLE
fix: only select the number from the branch name not the target as well

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -105,9 +105,9 @@ var newCmd = &cobra.Command{
 		} else {
 			targetRegex := getTargetRegex(config.Configuration.Targets)
 			re := regexp.MustCompile(targetRegex)
-			match := re.FindString(branchName)
-			if match != "" {
-				c.TicketId = &match
+			match := re.FindStringSubmatch(branchName)
+			if len(match) > 1 {
+				c.TicketId = &match[1]
 			} else {
 				prompt := promptui.Prompt{
 					Label: "Enter the ticket ID (optional)",
@@ -159,5 +159,5 @@ func getTargetRegex(targets []domain.Target) string {
 	for _, target := range targets {
 		targetNames = append(targetNames, target.Name)
 	}
-	return fmt.Sprintf(`(?i)(%s)-\d+`, strings.Join(targetNames, "|"))
+	return fmt.Sprintf(`(?i)(?:%s)-(\d+)`, strings.Join(targetNames, "|"))
 }


### PR DESCRIPTION
I forgot to update the auto selecting part. WIthout this the ticket id includes the target which makes it be something like: BPO-BPO-123 when generating the release notes.